### PR TITLE
fix bug when trying to draw large strings on the TJC display

### DIFF
--- a/klippy/extras/TJC3224.py
+++ b/klippy/extras/TJC3224.py
@@ -378,7 +378,7 @@ class TJC3224_LCD:
         self.byte(size)  # size
         self.word(font_color)
         self.word(background_color)
-        self.string(string)
+        self.string(string[:40])
         self.send()
 
     def draw_int_value(


### PR DESCRIPTION
As anything bigger than 40 char cant be displayed in the screen size anyways, I will truncate the string to 40 bytes and call it a day.