### PR TITLE
fix typo on bed temp command that caused a crash when setting a bed temp

### DIFF
--- a/klippy/extras/printerInterface.py
+++ b/klippy/extras/printerInterface.py
@@ -389,7 +389,7 @@ class PrinterData:
     def setExtTemp(self, target, toolnum=0):
         self.sendGCode("M104 T%s S%s" % (toolnum, str(target)))
 
-    def setExtTemp(self, target):
+    def setBedTemp(self, target):
         self.sendGCode('M104 S' + str(target))
 
     def setZOffset(self, offset):


### PR DESCRIPTION
Go fast and break things :)
```py
    def setExtTemp(self, target, toolnum=0):
        self.sendGCode("M104 T%s S%s" % (toolnum, str(target)))

    def setExtTemp(self, target): # This should be setBedTemp
        self.sendGCode('M104 S' + str(target))
```