### PR TITLE
Printer data now gets all necessary values at least once at startup

### DIFF
--- a/klippy/extras/e3v3se_display.py
+++ b/klippy/extras/e3v3se_display.py
@@ -580,6 +580,7 @@ class E3v3seDisplay:
         return self.reactor.NEVER
 
     def handle_ready(self):
+        self.pd.handle_ready()
         self.reactor.register_timer(
             self._reset_screen, self.reactor.monotonic())
          

--- a/klippy/extras/printerInterface.py
+++ b/klippy/extras/printerInterface.py
@@ -157,6 +157,10 @@ class PrinterData:
         self.gcode = self.printer.lookup_object("gcode")
         self.fl = []
         self.status = None
+
+    def handle_ready(self):
+        self.update_variable()
+        self.get_additional_values()
  
 
     def get_additional_values(self):


### PR DESCRIPTION
Fixed:

https://github.com/jpcurti/ender3-v3-se-klipper-with-display/assets/12000447/192f9420-3c78-4e63-9c83-8e146ee26c2c

