### PR TITLE
Z adjust adds to the value instead of setting it

### DIFF
--- a/klippy/extras/printerInterface.py
+++ b/klippy/extras/printerInterface.py
@@ -213,7 +213,7 @@ class PrinterData:
     def offset_z(self, new_offset):
         self.log('new z offset:', new_offset)
         self.BABY_Z_VAR = new_offset
-        self.sendGCode("SET_GCODE_OFFSET Z_ADJUST=+%s MOVE=1" % (new_offset))
+        self.sendGCode("SET_GCODE_OFFSET Z_ADJUST=%s MOVE=1" % (new_offset))
 
     def postREST(self, path, json):
         self.log("postREST called")


### PR DESCRIPTION
When you set the z offset, it tells the printer interface the new value but it then tries to add that to the original value you had, when it should be setting it.