### PR TITLE
Use arrow icon for folders in the file list

### DIFF
--- a/klippy/extras/e3v3se_display.py
+++ b/klippy/extras/e3v3se_display.py
@@ -2536,7 +2536,7 @@ class E3v3seDisplay:
     def Draw_SDItem(self, item, row=0):
         fl = self.pd.GetFiles()[item]
         if len(self.pd.fl[item].split('/')) > self.pd.subdirIndex + 1:
-            self.Draw_Menu_Line(row, False, fl)
+            self.Draw_Menu_Line(row, self.icon_more, fl)
         else:
             self.Draw_Menu_Line(row, self.icon_file, fl)
 


### PR DESCRIPTION
Show a folder in the file list using the "more" icon instead of leaving it blank