### PR TITLE
feature:  Add support for fast_up and fast_down encoder events

### DIFF
--- a/klippy/extras/e3v3se_display.py
+++ b/klippy/extras/e3v3se_display.py
@@ -556,7 +556,7 @@ class E3v3seDisplay:
         self._update_interval = 1
         self._update_timer = self.reactor.register_timer(self.EachMomentUpdate)
 
-    def key_event(self, key, event_time):
+    def key_event(self, key, eventtime):
         if key == 'click':
             self.encoder_state = self.ENCODER_DIFF_ENTER
         elif key == 'long_click':

--- a/klippy/extras/e3v3se_display.py
+++ b/klippy/extras/e3v3se_display.py
@@ -541,6 +541,7 @@ class E3v3seDisplay:
 
         # register for key events
         E3V3SEMenuKeys(config, self.key_event)
+        self.last_key_event_time = -1
 
         self.serial_bridge = E3V3SEPrinterSerialBridge(self.config)
 
@@ -554,7 +555,10 @@ class E3v3seDisplay:
         self._update_interval = 1
         self._update_timer = self.reactor.register_timer(self.EachMomentUpdate)
 
-    def key_event(self, key, eventtime):
+    def key_event(self, key, event_time):
+        if self.last_key_event_time == -1: 
+            self.last_key_event_time = event_time
+            
         if key == 'click':
             self.encoder_state = self.ENCODER_DIFF_ENTER
         elif key == 'long_click':
@@ -563,12 +567,19 @@ class E3v3seDisplay:
             self.encoder_state = self.ENCODER_DIFF_CCW
         elif key == 'down':
             self.encoder_state = self.ENCODER_DIFF_CW
-        self.encoder_has_data()
-
+        
+        self.encoder_has_data(event_time)
+        self.last_key_event_time = event_time
+        
     def get_encoder_state(self):
         last_state = self.encoder_state
         self.encoder_state = self.ENCODER_DIFF_NO
         return last_state
+
+    def get_encoder_multiplier(self, event_time):
+        fast_interval = 0.150 # 150ms
+        elapsed = event_time - self.last_key_event_time
+        return 10 if fast_interval >= elapsed > 0 else 1
 
     def _handle_serial_bridge_response(self, data):
         byte_debug = ' '.join(['0x{:02x}'.format(byte) for byte in data])
@@ -1324,11 +1335,13 @@ class E3v3seDisplay:
                 )
                 self.EncoderRateLimit = False
 
-    def HMI_Move_X(self):
+    def HMI_Move_X(self, event_time):
         """
         Handles the X axis move logic based on the encoder input.
         """
         encoder_state = self.get_encoder_state()
+        multiplier = self.get_encoder_multiplier(event_time)
+        
         if encoder_state == self.ENCODER_DIFF_NO:
             return
         elif encoder_state == self.ENCODER_DIFF_ENTER:
@@ -1352,9 +1365,9 @@ class E3v3seDisplay:
 
             return
         elif encoder_state == self.ENCODER_DIFF_CW:
-            self.pd.HMI_ValueStruct.Move_X_scale += 1
+            self.pd.HMI_ValueStruct.Move_X_scale += multiplier
         elif encoder_state == self.ENCODER_DIFF_CCW:
-            self.pd.HMI_ValueStruct.Move_X_scale -= 1
+            self.pd.HMI_ValueStruct.Move_X_scale -= multiplier
 
         if (
             self.pd.HMI_ValueStruct.Move_X_scale
@@ -1387,11 +1400,13 @@ class E3v3seDisplay:
             self.pd.HMI_ValueStruct.Move_X_scale,
         )
 
-    def HMI_Move_Y(self):
+    def HMI_Move_Y(self, event_time):
         """
         Handles the Y axis move logic based on the encoder input.
         """
         encoder_state = self.get_encoder_state()
+        multiplier = self.get_encoder_multiplier(event_time)
+        
         if encoder_state == self.ENCODER_DIFF_NO:
             return
         elif encoder_state == self.ENCODER_DIFF_ENTER:
@@ -1415,9 +1430,9 @@ class E3v3seDisplay:
 
             return
         elif encoder_state == self.ENCODER_DIFF_CW:
-            self.pd.HMI_ValueStruct.Move_Y_scale += 1
+            self.pd.HMI_ValueStruct.Move_Y_scale += multiplier
         elif encoder_state == self.ENCODER_DIFF_CCW:
-            self.pd.HMI_ValueStruct.Move_Y_scale -= 1
+            self.pd.HMI_ValueStruct.Move_Y_scale -= multiplier
 
         if (
             self.pd.HMI_ValueStruct.Move_Y_scale
@@ -1450,11 +1465,13 @@ class E3v3seDisplay:
             self.pd.HMI_ValueStruct.Move_Y_scale,
         )
 
-    def HMI_Move_Z(self):
+    def HMI_Move_Z(self, event_time):
         """
         Handles the Z axis move logic based on the encoder input.
         """
         encoder_state = self.get_encoder_state()
+        multiplier = self.get_encoder_multiplier(event_time)
+            
         if encoder_state == self.ENCODER_DIFF_NO:
             return
         elif encoder_state == self.ENCODER_DIFF_ENTER:
@@ -1477,9 +1494,9 @@ class E3v3seDisplay:
 
             return
         elif encoder_state == self.ENCODER_DIFF_CW:
-            self.pd.HMI_ValueStruct.Move_Z_scale += 1
+            self.pd.HMI_ValueStruct.Move_Z_scale += multiplier
         elif encoder_state == self.ENCODER_DIFF_CCW:
-            self.pd.HMI_ValueStruct.Move_Z_scale -= 1
+            self.pd.HMI_ValueStruct.Move_Z_scale -= multiplier
 
         if (
             self.pd.HMI_ValueStruct.Move_Z_scale
@@ -1512,12 +1529,14 @@ class E3v3seDisplay:
             self.pd.HMI_ValueStruct.Move_Z_scale,
         )
 
-    def HMI_Move_E(self):
+    def HMI_Move_E(self, event_time):
         """
         Handles the Extruder move logic based on the encoder input.
         """
         self.pd.last_E_scale = 0
         encoder_state = self.get_encoder_state()
+        multiplier = self.get_encoder_multiplier(event_time)
+        
         if encoder_state == self.ENCODER_DIFF_NO:
             return
 
@@ -1537,11 +1556,10 @@ class E3v3seDisplay:
                 self.pd.HMI_ValueStruct.Move_E_scale,
             )
             self.pd.moveAbsolute("E", self.pd.current_position.e, 300)
-
         elif encoder_state == self.ENCODER_DIFF_CW:
-            self.pd.HMI_ValueStruct.Move_E_scale += 1
+            self.pd.HMI_ValueStruct.Move_E_scale += multiplier
         elif encoder_state == self.ENCODER_DIFF_CCW:
-            self.pd.HMI_ValueStruct.Move_E_scale -= 1
+            self.pd.HMI_ValueStruct.Move_E_scale -= multiplier
 
         if (self.pd.HMI_ValueStruct.Move_E_scale - self.pd.last_E_scale) > (
             self.pd.EXTRUDE_MAXLENGTH
@@ -3938,7 +3956,7 @@ class E3v3seDisplay:
 
         return eventtime + self._update_interval
 
-    def encoder_has_data(self):
+    def encoder_has_data(self, event_time):
         if self.checkkey == self.MainMenu:
             self.HMI_MainMenu()
         elif self.checkkey == self.SelectFile:
@@ -3974,13 +3992,13 @@ class E3v3seDisplay:
         elif self.checkkey == self.Step:
             self.HMI_Step()
         elif self.checkkey == self.Move_X:
-            self.HMI_Move_X()
+            self.HMI_Move_X(event_time)
         elif self.checkkey == self.Move_Y:
-            self.HMI_Move_Y()
+            self.HMI_Move_Y(event_time)
         elif self.checkkey == self.Move_Z:
-            self.HMI_Move_Z()
+            self.HMI_Move_Z(event_time)
         elif self.checkkey == self.Extruder:
-            self.HMI_Move_E()
+            self.HMI_Move_E(event_time)
         elif self.checkkey == self.ETemp:
             self.HMI_ETemp()
         elif self.checkkey == self.Homeoffset:

--- a/klippy/extras/e3v3se_display.py
+++ b/klippy/extras/e3v3se_display.py
@@ -146,9 +146,11 @@ class E3v3seDisplay:
 
     ENCODER_DIFF_NO = 0  # no state
     ENCODER_DIFF_CW = 1  # clockwise rotation
-    ENCODER_DIFF_CCW = 2  # counterclockwise rotation
-    ENCODER_DIFF_ENTER = 3  # click
-    ENCODER_DIFF_LONG_ENTER = 4  # long click
+    ENCODER_DIFF_FAST_CW = 2  # fast clockwise rotation
+    ENCODER_DIFF_CCW = 3  # counterclockwise rotation
+    ENCODER_DIFF_FAST_CCW = 4  # fast counterclockwise rotation
+    ENCODER_DIFF_ENTER = 5  # click
+    ENCODER_DIFF_LONG_ENTER = 6  # long click
 
     TROWS = 6
     MROWS = TROWS - 1  # Total rows, and other-than-Back
@@ -541,7 +543,6 @@ class E3v3seDisplay:
 
         # register for key events
         E3V3SEMenuKeys(config, self.key_event)
-        self.last_key_event_time = -1
 
         self.serial_bridge = E3V3SEPrinterSerialBridge(self.config)
 
@@ -556,9 +557,6 @@ class E3v3seDisplay:
         self._update_timer = self.reactor.register_timer(self.EachMomentUpdate)
 
     def key_event(self, key, event_time):
-        if self.last_key_event_time == -1: 
-            self.last_key_event_time = event_time
-            
         if key == 'click':
             self.encoder_state = self.ENCODER_DIFF_ENTER
         elif key == 'long_click':
@@ -567,9 +565,12 @@ class E3v3seDisplay:
             self.encoder_state = self.ENCODER_DIFF_CCW
         elif key == 'down':
             self.encoder_state = self.ENCODER_DIFF_CW
-        
-        self.encoder_has_data(event_time)
-        self.last_key_event_time = event_time
+        elif key == 'fast_up':
+            self.encoder_state = self.ENCODER_DIFF_FAST_CCW
+        elif key == 'fast_down':
+            self.encoder_state = self.ENCODER_DIFF_FAST_CW
+
+        self.encoder_has_data()
         
     def get_encoder_state(self):
         last_state = self.encoder_state
@@ -640,7 +641,7 @@ class E3v3seDisplay:
         encoder_state = self.get_encoder_state()
         if encoder_state == self.ENCODER_DIFF_NO:
             return
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_page.inc(4):
                 if self.select_page.now == 0:
                     self.icon_Print()
@@ -656,7 +657,7 @@ class E3v3seDisplay:
                         self.icon_Leveling(True)
                     else:
                         self.icon_StartInfo(True)
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_page.dec():
                 if self.select_page.now == 0:
                     self.icon_Print()
@@ -708,7 +709,7 @@ class E3v3seDisplay:
 
         fullCnt = len(self.pd.GetFiles())
 
-        if encoder_state == self.ENCODER_DIFF_CW and fullCnt:
+        if (encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW) and fullCnt:
             if self.select_file.inc(1 + fullCnt):
                 itemnum = self.select_file.now - 1  # -1 for "Back"
                 if (
@@ -724,7 +725,7 @@ class E3v3seDisplay:
                     self.Move_Highlight(
                         1, self.select_file.now + self.MROWS - self.index_file
                     )  # Just move highlight
-        elif encoder_state == self.ENCODER_DIFF_CCW and fullCnt:
+        elif (encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW) and fullCnt:
             if self.select_file.dec():
                 itemnum = self.select_file.now - 1  # -1 for "Back"
                 if (
@@ -777,7 +778,7 @@ class E3v3seDisplay:
         if encoder_state == self.ENCODER_DIFF_NO:
             return
 
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_prepare.inc(1 + self.PREPARE_CASE_TOTAL):
                 if (
                     self.select_prepare.now > self.MROWS
@@ -805,8 +806,7 @@ class E3v3seDisplay:
                     self.Move_Highlight(
                         1, self.select_prepare.now + self.MROWS - self.index_prepare
                     )
-
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_prepare.dec():
                 if self.select_prepare.now < self.index_prepare - self.MROWS:
                     self.index_prepare -= 1
@@ -893,7 +893,7 @@ class E3v3seDisplay:
         if encoder_state == self.ENCODER_DIFF_NO:
             return
 
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_control.inc(1 + self.CONTROL_CASE_TOTAL):
                 if (
                     self.select_control.now > self.MROWS
@@ -927,7 +927,7 @@ class E3v3seDisplay:
                     self.Move_Highlight(
                         1, self.select_control.now + self.MROWS - self.index_control
                     )
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_control.dec():
                 if self.select_control.now < self.index_control - self.MROWS:
                     self.index_control -= 1
@@ -1006,7 +1006,7 @@ class E3v3seDisplay:
                 self.dwin_abort_flag = True  # Reset feedrate, return to Home
             return
 
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_print.inc(3):
                 if self.select_print.now == 0:
                     self.show_tune()
@@ -1022,7 +1022,7 @@ class E3v3seDisplay:
                     else:
                         self.show_pause()
                     self.show_stop()
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_print.dec():
                 if self.select_print.now == 0:
                     self.show_tune()
@@ -1070,14 +1070,14 @@ class E3v3seDisplay:
         update = False
         error = False
         
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if math.floor(current_pos - step) <= min_z:
                 self.error(f"Ignoring move '{current_pos - step}' as it is lower than Z limit '{min_z}'!")
                 error = True
             else:
                 self.gcode.run_script_from_command(f"TESTZ Z=-{step}")
             update = True
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             step = self.MANUAL_PROBE_STEPS[self.manual_probe_step_index]
             if math.ceil(current_pos + step) >= max_z:
                 self.error(f"Ignoring move '{current_pos + step}' as it is greater than Z limit '{max_z}'!")
@@ -1100,11 +1100,11 @@ class E3v3seDisplay:
         encoder_state = self.get_encoder_state()
         if encoder_state == self.ENCODER_DIFF_NO:
             return
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             self.select_cancel.set(1)
             self.select_confirm.reset()
             self.Draw_Confirm_Cancel_Buttons()
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             self.select_confirm.set(1)
             self.select_cancel.reset()
             self.Draw_Confirm_Cancel_Buttons()
@@ -1128,7 +1128,7 @@ class E3v3seDisplay:
         encoder_state = self.get_encoder_state()
         if encoder_state == self.ENCODER_DIFF_NO:
             return
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_tune.inc(1 + self.TUNE_CASE_TOTAL):
                 if (
                     self.select_tune.now > self.MROWS
@@ -1140,7 +1140,7 @@ class E3v3seDisplay:
                     self.Move_Highlight(
                         1, self.select_tune.now + self.MROWS - self.index_tune
                     )
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_tune.dec():
                 if self.select_tune.now < self.index_tune - self.MROWS:
                     self.index_tune -= 1
@@ -1192,9 +1192,12 @@ class E3v3seDisplay:
 
         if encoder_state == self.ENCODER_DIFF_CW:
             self.pd.HMI_ValueStruct.print_speed += 1
-
         elif encoder_state == self.ENCODER_DIFF_CCW:
             self.pd.HMI_ValueStruct.print_speed -= 1
+        elif encoder_state == self.ENCODER_DIFF_FAST_CW:
+            self.pd.HMI_ValueStruct.print_speed += 10
+        elif encoder_state == self.ENCODER_DIFF_FAST_CCW:
+            self.pd.HMI_ValueStruct.print_speed -= 10
 
         elif encoder_state == self.ENCODER_DIFF_ENTER:
             self.checkkey = self.Tune
@@ -1238,10 +1241,10 @@ class E3v3seDisplay:
                 return
 
         # Avoid flicker by updating only the previous menu
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_axis.inc(1 + 4):
                 self.Move_Highlight(1, self.select_axis.now)
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_axis.dec():
                 self.Move_Highlight(-1, self.select_axis.now)
         elif encoder_state == self.ENCODER_DIFF_ENTER:
@@ -1335,12 +1338,11 @@ class E3v3seDisplay:
                 )
                 self.EncoderRateLimit = False
 
-    def HMI_Move_X(self, event_time):
+    def HMI_Move_X(self):
         """
         Handles the X axis move logic based on the encoder input.
         """
         encoder_state = self.get_encoder_state()
-        multiplier = self.get_encoder_multiplier(event_time)
         
         if encoder_state == self.ENCODER_DIFF_NO:
             return
@@ -1365,9 +1367,13 @@ class E3v3seDisplay:
 
             return
         elif encoder_state == self.ENCODER_DIFF_CW:
-            self.pd.HMI_ValueStruct.Move_X_scale += multiplier
+            self.pd.HMI_ValueStruct.Move_X_scale += 1
         elif encoder_state == self.ENCODER_DIFF_CCW:
-            self.pd.HMI_ValueStruct.Move_X_scale -= multiplier
+            self.pd.HMI_ValueStruct.Move_X_scale -= 1
+        elif encoder_state == self.ENCODER_DIFF_FAST_CW:
+            self.pd.HMI_ValueStruct.Move_X_scale += 10
+        elif encoder_state == self.ENCODER_DIFF_FAST_CCW:
+            self.pd.HMI_ValueStruct.Move_X_scale -= 10
 
         if (
             self.pd.HMI_ValueStruct.Move_X_scale
@@ -1400,12 +1406,11 @@ class E3v3seDisplay:
             self.pd.HMI_ValueStruct.Move_X_scale,
         )
 
-    def HMI_Move_Y(self, event_time):
+    def HMI_Move_Y(self):
         """
         Handles the Y axis move logic based on the encoder input.
         """
         encoder_state = self.get_encoder_state()
-        multiplier = self.get_encoder_multiplier(event_time)
         
         if encoder_state == self.ENCODER_DIFF_NO:
             return
@@ -1430,9 +1435,13 @@ class E3v3seDisplay:
 
             return
         elif encoder_state == self.ENCODER_DIFF_CW:
-            self.pd.HMI_ValueStruct.Move_Y_scale += multiplier
+            self.pd.HMI_ValueStruct.Move_Y_scale += 1
         elif encoder_state == self.ENCODER_DIFF_CCW:
-            self.pd.HMI_ValueStruct.Move_Y_scale -= multiplier
+            self.pd.HMI_ValueStruct.Move_Y_scale -= 1
+        elif encoder_state == self.ENCODER_DIFF_FAST_CW:
+            self.pd.HMI_ValueStruct.Move_Y_scale += 10
+        elif encoder_state == self.ENCODER_DIFF_FAST_CCW:
+            self.pd.HMI_ValueStruct.Move_Y_scale -= 10
 
         if (
             self.pd.HMI_ValueStruct.Move_Y_scale
@@ -1465,12 +1474,11 @@ class E3v3seDisplay:
             self.pd.HMI_ValueStruct.Move_Y_scale,
         )
 
-    def HMI_Move_Z(self, event_time):
+    def HMI_Move_Z(self):
         """
         Handles the Z axis move logic based on the encoder input.
         """
         encoder_state = self.get_encoder_state()
-        multiplier = self.get_encoder_multiplier(event_time)
             
         if encoder_state == self.ENCODER_DIFF_NO:
             return
@@ -1494,9 +1502,13 @@ class E3v3seDisplay:
 
             return
         elif encoder_state == self.ENCODER_DIFF_CW:
-            self.pd.HMI_ValueStruct.Move_Z_scale += multiplier
+            self.pd.HMI_ValueStruct.Move_Z_scale += 1
         elif encoder_state == self.ENCODER_DIFF_CCW:
-            self.pd.HMI_ValueStruct.Move_Z_scale -= multiplier
+            self.pd.HMI_ValueStruct.Move_Z_scale -= 1
+        elif encoder_state == self.ENCODER_DIFF_FAST_CW:
+            self.pd.HMI_ValueStruct.Move_Z_scale += 10
+        elif encoder_state == self.ENCODER_DIFF_FAST_CCW:
+            self.pd.HMI_ValueStruct.Move_Z_scale -= 10
 
         if (
             self.pd.HMI_ValueStruct.Move_Z_scale
@@ -1529,13 +1541,12 @@ class E3v3seDisplay:
             self.pd.HMI_ValueStruct.Move_Z_scale,
         )
 
-    def HMI_Move_E(self, event_time):
+    def HMI_Move_E(self):
         """
         Handles the Extruder move logic based on the encoder input.
         """
         self.pd.last_E_scale = 0
         encoder_state = self.get_encoder_state()
-        multiplier = self.get_encoder_multiplier(event_time)
         
         if encoder_state == self.ENCODER_DIFF_NO:
             return
@@ -1557,9 +1568,13 @@ class E3v3seDisplay:
             )
             self.pd.moveAbsolute("E", self.pd.current_position.e, 300)
         elif encoder_state == self.ENCODER_DIFF_CW:
-            self.pd.HMI_ValueStruct.Move_E_scale += multiplier
+            self.pd.HMI_ValueStruct.Move_E_scale += 1
         elif encoder_state == self.ENCODER_DIFF_CCW:
-            self.pd.HMI_ValueStruct.Move_E_scale -= multiplier
+            self.pd.HMI_ValueStruct.Move_E_scale -= 1
+        elif encoder_state == self.ENCODER_DIFF_FAST_CW:
+            self.pd.HMI_ValueStruct.Move_E_scale += 10
+        elif encoder_state == self.ENCODER_DIFF_FAST_CCW:
+            self.pd.HMI_ValueStruct.Move_E_scale -= 10
 
         if (self.pd.HMI_ValueStruct.Move_E_scale - self.pd.last_E_scale) > (
             self.pd.EXTRUDE_MAXLENGTH
@@ -1591,10 +1606,10 @@ class E3v3seDisplay:
         if encoder_state == self.ENCODER_DIFF_NO:
             return
 
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_temp.inc(1 + self.TEMP_CASE_TOTAL):
                 self.Move_Highlight(1, self.select_temp.now)
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_temp.dec():
                 self.Move_Highlight(-1, self.select_temp.now)
         elif encoder_state == self.ENCODER_DIFF_ENTER:
@@ -1801,10 +1816,10 @@ class E3v3seDisplay:
         if encoder_state == self.ENCODER_DIFF_NO:
             return
         # Avoid flicker by updating only the previous menu
-        elif encoder_state == self.ENCODER_DIFF_CW:
+        elif encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_PLA.inc(1 + self.PREHEAT_CASE_TOTAL):
                 self.Move_Highlight(1, self.select_PLA.now)
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_PLA.dec():
                 self.Move_Highlight(-1, self.select_PLA.now)
         elif encoder_state == self.ENCODER_DIFF_ENTER:
@@ -1872,10 +1887,10 @@ class E3v3seDisplay:
         if encoder_state == self.ENCODER_DIFF_NO:
             return
         # Avoid flicker by updating only the previous menu
-        elif encoder_state == self.ENCODER_DIFF_CW:
+        elif encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_TPU.inc(1 + self.PREHEAT_CASE_TOTAL):
                 self.Move_Highlight(1, self.select_TPU.now)
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_TPU.dec():
                 self.Move_Highlight(-1, self.select_TPU.now)
         elif encoder_state == self.ENCODER_DIFF_ENTER:
@@ -2018,12 +2033,14 @@ class E3v3seDisplay:
                 )
                 self.pd.setTargetHotend(self.pd.HMI_ValueStruct.E_Temp, 0)
             return
-
         elif encoder_state == self.ENCODER_DIFF_CW:
             self.pd.HMI_ValueStruct.E_Temp += 1
-
         elif encoder_state == self.ENCODER_DIFF_CCW:
             self.pd.HMI_ValueStruct.E_Temp -= 1
+        elif encoder_state == self.ENCODER_DIFF_FAST_CW:
+            self.pd.HMI_ValueStruct.E_Temp += 10
+        elif encoder_state == self.ENCODER_DIFF_FAST_CCW:
+            self.pd.HMI_ValueStruct.E_Temp -= 10
 
         # E_Temp limit
         if self.pd.HMI_ValueStruct.E_Temp > self.pd.MAX_E_TEMP:
@@ -2122,12 +2139,14 @@ class E3v3seDisplay:
                 )
                 self.pd.setTargetHotend(self.pd.HMI_ValueStruct.Bed_Temp, 0)
             return
-
         elif encoder_state == self.ENCODER_DIFF_CW:
             self.pd.HMI_ValueStruct.Bed_Temp += 1
-
         elif encoder_state == self.ENCODER_DIFF_CCW:
             self.pd.HMI_ValueStruct.Bed_Temp -= 1
+        elif encoder_state == self.ENCODER_DIFF_FAST_CW:
+            self.pd.HMI_ValueStruct.Bed_Temp += 10
+        elif encoder_state == self.ENCODER_DIFF_FAST_CCW:
+            self.pd.HMI_ValueStruct.Bed_Temp -= 10
 
         # Bed_Temp limit
         if self.pd.HMI_ValueStruct.Bed_Temp > self.pd.BED_MAX_TARGET:
@@ -2154,10 +2173,10 @@ class E3v3seDisplay:
         encoder_state = self.get_encoder_state()
         if encoder_state == self.ENCODER_DIFF_NO:
             return
-        if encoder_state == self.ENCODER_DIFF_CW:
+        if encoder_state == self.ENCODER_DIFF_CW or encoder_state == self.ENCODER_DIFF_FAST_CW:
             if self.select_motion.inc(1 + self.MOTION_CASE_TOTAL):
                 self.Move_Highlight(1, self.select_motion.now)
-        elif encoder_state == self.ENCODER_DIFF_CCW:
+        elif encoder_state == self.ENCODER_DIFF_CCW or encoder_state == self.ENCODER_DIFF_FAST_CCW:
             if self.select_motion.dec():
                 self.Move_Highlight(-1, self.select_motion.now)
         elif encoder_state == self.ENCODER_DIFF_ENTER:
@@ -2185,9 +2204,7 @@ class E3v3seDisplay:
         else:
             zoff_line = self.TUNE_CASE_ZOFF + self.MROWS - self.index_tune
 
-        if (
-            encoder_state == self.ENCODER_DIFF_ENTER
-        ):  # if (applyencoder(encoder_diffstate, offset_value))
+        if encoder_state == self.ENCODER_DIFF_ENTER:
             self.EncoderRateLimit = True
             if self.pd.HAS_BED_PROBE:
                 self.pd.offset_z(self.dwin_zoffset)
@@ -2210,11 +2227,14 @@ class E3v3seDisplay:
             )
 
             return
-
         elif encoder_state == self.ENCODER_DIFF_CW:
             self.pd.HMI_ValueStruct.offset_value += 1
         elif encoder_state == self.ENCODER_DIFF_CCW:
             self.pd.HMI_ValueStruct.offset_value -= 1
+        elif encoder_state == self.ENCODER_DIFF_FAST_CW:
+            self.pd.HMI_ValueStruct.offset_value += 10
+        elif encoder_state == self.ENCODER_DIFF_FAST_CCW:
+            self.pd.HMI_ValueStruct.offset_value -= 10
 
         if (
             self.pd.HMI_ValueStruct.offset_value
@@ -3956,7 +3976,7 @@ class E3v3seDisplay:
 
         return eventtime + self._update_interval
 
-    def encoder_has_data(self, event_time):
+    def encoder_has_data(self):
         if self.checkkey == self.MainMenu:
             self.HMI_MainMenu()
         elif self.checkkey == self.SelectFile:
@@ -3992,13 +4012,13 @@ class E3v3seDisplay:
         elif self.checkkey == self.Step:
             self.HMI_Step()
         elif self.checkkey == self.Move_X:
-            self.HMI_Move_X(event_time)
+            self.HMI_Move_X()
         elif self.checkkey == self.Move_Y:
-            self.HMI_Move_Y(event_time)
+            self.HMI_Move_Y()
         elif self.checkkey == self.Move_Z:
-            self.HMI_Move_Z(event_time)
+            self.HMI_Move_Z()
         elif self.checkkey == self.Extruder:
-            self.HMI_Move_E(event_time)
+            self.HMI_Move_E()
         elif self.checkkey == self.ETemp:
             self.HMI_ETemp()
         elif self.checkkey == self.Homeoffset:


### PR DESCRIPTION
This pull request to `klippy/extras/e3v3se_display.py` includes changes to support fast encoder rotations and improve the handling of key events.

Fixes #42 


Enhancements to encoder handling:

* Added new encoder states for fast clockwise and counterclockwise rotations (`ENCODER_DIFF_FAST_CW` and `ENCODER_DIFF_FAST_CCW`) and updated the existing states to accommodate these changes.
* Updated the `key_event` method to handle fast rotation events (`fast_up` and `fast_down`).
* Added the `get_encoder_multiplier` method to determine the multiplier for fast rotations based on the elapsed time between events.

Updates to menu navigation:

* Modified various methods (`HMI_MainMenu`, `HMI_SelectFile`, `HMI_Prepare`, `HMI_Control`, `HMI_Printing`, `HMI_ManualProbe`, `HMI_PauseOrStop`, `HMI_Tune`, `HMI_PrintSpeed`, `HMI_AxisMove`, `HMI_Move_X`, `HMI_Move_Y`, `HMI_Move_Z`, `HMI_Move_E`, `HMI_Temperature`, `HMI_PLAPreheatSetting`) to handle the new fast rotation states for smoother and faster navigation. [[1]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L632-R644) [[2]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L648-R660) [[3]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L700-R712) [[4]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L716-R728) [[5]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L769-R781) [[6]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L797-R809) [[7]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L885-R896) [[8]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L919-R930) [[9]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L998-R1009) [[10]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1014-R1025) [[11]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1062-R1080) [[12]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1092-R1107) [[13]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1120-R1131) [[14]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1132-R1143) [[15]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1184-R1200) [[16]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1230-R1247) [[17]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0R1346) [[18]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0R1373-R1376) [[19]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0R1414) [[20]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0R1441-R1444) [[21]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0R1482) [[22]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0R1508-R1511) [[23]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0R1550) [[24]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1540-R1577) [[25]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1576-R1612) [[26]](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L1786-R1822)