### PR TITLE
fix: Change draw integer type from unsigned to signed

### DIFF
--- a/klippy/extras/TJC3224.py
+++ b/klippy/extras/TJC3224.py
@@ -96,7 +96,7 @@ class TJC3224_LCD:
         :param lval: The four-byte value to be appended.
         :type lval: int
         """
-        self.data_frame += int(long_val).to_bytes(4, byteorder="big")
+        self.data_frame += int(long_val).to_bytes(4, byteorder="big", signed=True)
 
     def double_64(self, double_val):
         """


### PR DESCRIPTION
Fixes an issue where if you open the move menu and an axis position is negative, there will be an error and klipper shuts down.