### PR TITLE
Fix/empty misc menu message

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,42 @@ A section called `[e3v3se_display]` need to be added to your `printer.cfg` to en
 language: portuguese
 logging: True
 ```
+### Custom macros
+The new 'Misc' menu list a set of custom macros that can be defined on your `printer.cfg`.
+You can use this to call macros defined on Klipper using your screen directly, e.g.: Load/Unload filament, calibrate Z offset, calibrate bed mesh, clean nozzle, etc.
+
+On your `printer.cfg` you can define the macros using a new config section `[e3v3se_display MACRO%I]` where `%i` is the macro number (This should be unique per macro). The following properties are available:
+
+| Property | Data type | Required | Description                                                      |
+|----------|-----------|----------|------------------------------------------------------------------|
+| label    | Text      | Yes      | Text to be displayed on the screen                               |
+| icon     | Integer   | No       | Internal firmware icon. Defaults to 14 (file icon)               |
+| gcode    | Text      | Yes      | GCODE to be run when the item is selected.  i.e `G28` for homing |
+
+Some examples for your inspiration:
+
+```yaml
+[e3v3se_display MACRO1]
+gcode: LOAD_FILAMENT
+label: Load filament
+icon: 14
+[e3v3se_display MACRO2]
+gcode: UNLOAD_FILAMENT
+label: Unload filament
+icon: 14
+[e3v3se_display MACRO3]
+gcode: CALIBRATE_Z_OFFSET
+label: Calibrate Z offset
+icon: 12
+[e3v3se_display MACRO4]
+gcode: CALIBRATE_BED_MESH
+label: Calibrate bed mesh
+icon: 29
+[e3v3se_display MACRO5]
+gcode: CLEAN_NOZZLE
+label: Clean nozzle
+icon: 9
+```
 
 ## Supported features
 The currently supported features are:
@@ -52,7 +88,8 @@ The currently supported features are:
 | Set max speed          | &cross; |
 | Set max acceleration   | &cross; |
 | Set steps per-mm       | &cross; |
-| Leveling Menu          | &cross; |
+| Manual probe popup     | &check; |
+| Custom macros menu     | &check; |
 
 Features that are not available are shown as a pop-up:
 

--- a/klippy/extras/TJC3224.py
+++ b/klippy/extras/TJC3224.py
@@ -411,7 +411,7 @@ class TJC3224_LCD:
             size,
             font_color,
             background_color,
-            int(x - len(string * char_width) / 2.0),
+            int(x - (len(string) * char_width) / 2.0),
             int(y - char_height / 2.0),
             string
         )

--- a/klippy/extras/e3v3se_display.py
+++ b/klippy/extras/e3v3se_display.py
@@ -2933,22 +2933,40 @@ class E3v3seDisplay:
             for i in range(custom_macro_count):
                 self.Draw_CustomMacroItem(i, i + 1)
         else:
-            self.lcd.draw_rectangle(
-                1,
-                self.color_background_red,
-                11,
-                25,
-                self.MBASE(3) - 10,
-                self.lcd.screen_width - 10
-            )
-            self.lcd.draw_string(
+            self.lcd.draw_string_centered(
                 False,
                 self.lcd.font_16x32,
-                self.color_yellow,
-                self.color_background_red,
-                (self.lcd.screen_width - 9 * 16) / 2,
-                self.MBASE(3),
-                "No Macros"
+                self.color_white,
+                self.color_background_black,
+                14,
+                32,
+                self.lcd.screen_width / 2,
+                self.lcd.screen_height / 2,
+                "No macros"
+            )
+
+            self.lcd.draw_string_centered(
+                False,
+                self.lcd.font_8x8,
+                self.color_white,
+                self.color_background_black,
+                self.MENU_CHR_W,
+                0,
+                self.lcd.screen_width / 2,
+                self.lcd.screen_height / 2 + 32,
+                "Please follow WIKI"
+            )
+
+            self.lcd.draw_string_centered(
+                False,
+                self.lcd.font_8x8,
+                self.color_white,
+                self.color_background_black,
+                self.MENU_CHR_W,
+                0,
+                self.lcd.screen_width / 2,
+                self.lcd.screen_height / 2 + 45,
+                "to include macros here"
             )
 
     def Draw_Info_Menu(self):


### PR DESCRIPTION
This pull request includes changes to the `README.md` file and updates to the `klippy/extras/TJC3224.py` and `klippy/extras/e3v3se_display.py` scripts. The changes focus on adding new features, improving the display of custom macros, and fixing a bug in the string centering calculation.

Fixed #109 

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R69): Added a new section on custom macros, including instructions for defining macros in `printer.cfg` and examples. Updated the supported features table to reflect the new custom macros menu. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R92)

### Code improvements:

* [`klippy/extras/TJC3224.py`](diffhunk://#diff-8ec30c8b49e5a6f2cb8215b59cf5cd6adef81e1c0440801eb70e6dbae4370586L414-R414): Fixed a bug in the `draw_string_centered` method by correcting the calculation of the string's centered position.
* [`klippy/extras/e3v3se_display.py`](diffhunk://#diff-801ee7361a2a85d37830418560e0612dbc554b8730a07d8ef20543db91825cc0L2936-R2969): Enhanced the `Draw_Misc_Menu` method to use `draw_string_centered` for displaying messages when no macros are defined, and added additional instructions for users.